### PR TITLE
New version to support phpunit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ sudo: false
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7
-  - hhvm
 
 matrix:
     include:
-        - php: 5.4
+        - php: 7
           env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
     allow_failures:
         - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,8 @@ sudo: false
 language: php
 
 php:
-  - 7
-
-matrix:
-    include:
-        - php: 7
-          env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-    allow_failures:
-        - php: hhvm
+  - 7.1
+  - 7.2
 
 before_script:
     - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ You can either use the `trait` or `class` version.
 namespace EnricoStahn\JsonAssert\Tests;
 
 use EnricoStahn\JsonAssert\Assert as JsonAssert;
+use PHPUnit\Framework\TestCase;
 
-class MyTestCase extends \PHPUnit_Framework_TestCase
+class MyTestCase extends TestCase
 {
     use JsonAssert;
     
@@ -86,7 +87,7 @@ class MyTestCase extends \PHPUnit_Framework_TestCase
 
 ### Class
 
-In case you don't want to use the `trait` you can use the provided class wich extends from `\PHPUnit_Framework_TestCase`.
+In case you don't want to use the `trait` you can use the provided class wich extends from `PHPUnit\Framework\TestCase`.
 You can either extend your test case or use the static methods like below.
 
 ```php
@@ -95,8 +96,9 @@ You can either extend your test case or use the static methods like below.
 namespace EnricoStahn\JsonAssert\Tests;
 
 use EnricoStahn\JsonAssert\AssertClass as JsonAssert;
+use PHPUnit\Framework\TestCase;
 
-class MyTestCase extends \PHPUnit_Framework_TestCase
+class MyTestCase extends TestCase
 {
     public function testJsonDocumentIsValid()
     {

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^5.4 || ^7.0",
+        "php": "^7.0",
         "justinrainbow/json-schema": "^2.0",
         "mtdowling/jmespath.php": "^2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8|~5.2",
+        "phpunit/phpunit": "^6",
         "codacy/coverage": "dev-master",
         "symfony/http-foundation": "^2.8|^3.0"
     },

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -51,7 +51,7 @@ trait Assert
         }, $validator->getErrors());
         $messages[] = '- Response: '.json_encode($content);
 
-        \PHPUnit_Framework_Assert::assertTrue($validator->isValid(), implode("\n", $messages));
+        \PHPUnit\Framework\Assert::assertTrue($validator->isValid(), implode("\n", $messages));
     }
 
     /**
@@ -84,8 +84,8 @@ trait Assert
     {
         $result = \JmesPath\Env::search($expression, $json);
 
-        \PHPUnit_Framework_Assert::assertEquals($expected, $result);
-        \PHPUnit_Framework_Assert::assertInternalType(gettype($expected), $result);
+        \PHPUnit\Framework\Assert::assertEquals($expected, $result);
+        \PHPUnit\Framework\Assert::assertInternalType(gettype($expected), $result);
     }
 
     /**

--- a/src/AssertClass.php
+++ b/src/AssertClass.php
@@ -11,7 +11,9 @@
 
 namespace EnricoStahn\JsonAssert;
 
-class AssertClass extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AssertClass extends TestCase
 {
     use Assert;
 }

--- a/src/Extension/Symfony.php
+++ b/src/Extension/Symfony.php
@@ -69,12 +69,12 @@ trait Symfony
      */
     public static function assertJsonResponse(Response $response, $statusCode = 200)
     {
-        \PHPUnit_Framework_Assert::assertEquals(
+        \PHPUnit\Framework\Assert::assertEquals(
             $statusCode,
             $response->getStatusCode(),
             $response->getContent()
         );
-        \PHPUnit_Framework_Assert::assertTrue(
+        \PHPUnit\Framework\Assert::assertTrue(
             $response->headers->contains('Content-Type', 'application/json'),
             $response->headers
         );

--- a/src/Extension/SymfonyClass.php
+++ b/src/Extension/SymfonyClass.php
@@ -11,7 +11,9 @@
 
 namespace EnricoStahn\JsonAssert\Extension;
 
-class SymfonyClass extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SymfonyClass extends TestCase
 {
     use Symfony;
 }

--- a/tests/AssertClassTest.php
+++ b/tests/AssertClassTest.php
@@ -12,8 +12,9 @@
 namespace EnricoStahn\JsonAssert\Tests;
 
 use EnricoStahn\JsonAssert\AssertClass;
+use PHPUnit\Framework\TestCase;
 
-class AssertClassTest extends \PHPUnit_Framework_TestCase
+class AssertClassTest extends TestCase
 {
     public function testClassInstance()
     {

--- a/tests/AssertTraitImpl.php
+++ b/tests/AssertTraitImpl.php
@@ -12,8 +12,9 @@
 namespace EnricoStahn\JsonAssert\Tests;
 
 use EnricoStahn\JsonAssert\Assert as JsonAssert;
+use PHPUnit\Framework\TestCase;
 
-class AssertTraitImpl extends \PHPUnit_Framework_TestCase
+class AssertTraitImpl extends TestCase
 {
     use JsonAssert;
 }

--- a/tests/AssertTraitTest.php
+++ b/tests/AssertTraitTest.php
@@ -123,14 +123,14 @@ class AssertTraitTest extends TestCase
     }
 
     /**
-     * @dataProvider testGetJsonObjectProvider
+     * @dataProvider jsonObjectProvider
      */
     public function testGetJsonObject($expected, $actual)
     {
         self::assertEquals($expected, AssertTraitImpl::getJsonObject($actual));
     }
 
-    public function testGetJsonObjectProvider()
+    public function jsonObjectProvider()
     {
         return [
             [[], []],

--- a/tests/AssertTraitTest.php
+++ b/tests/AssertTraitTest.php
@@ -11,7 +11,10 @@
 
 namespace EnricoStahn\JsonAssert\Tests;
 
-class AssertTraitTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+class AssertTraitTest extends TestCase
 {
     /**
      * Showcase for the Wiki.
@@ -33,7 +36,7 @@ class AssertTraitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertJsonMatchesSchemaFail()
     {
@@ -50,12 +53,12 @@ class AssertTraitTest extends \PHPUnit_Framework_TestCase
 
         try {
             AssertTraitImpl::assertJsonMatchesSchema(Utils::getSchemaPath('test.schema.json'), $content);
-        } catch (\PHPUnit_Framework_ExpectationFailedException $exception) {
+        } catch (ExpectationFailedException $exception) {
             self::assertContains('- Property: foo, Contraint: type, Message: String value found, but an integer is required', $exception->getMessage());
             self::assertContains('- Response: {"foo":"123"}', $exception->getMessage());
         }
 
-        self::assertInstanceOf('PHPUnit_Framework_ExpectationFailedException', $exception);
+        self::assertInstanceOf('\PHPUnit\Framework\ExpectationFailedException', $exception);
     }
 
     /**
@@ -69,7 +72,7 @@ class AssertTraitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertJsonMatchesSchemaWithRefsFails()
     {
@@ -110,7 +113,7 @@ class AssertTraitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertJsonValueEqualsFailsOnWrongDataType()
     {

--- a/tests/Extension/SymfonyTest.php
+++ b/tests/Extension/SymfonyTest.php
@@ -13,9 +13,10 @@ namespace EnricoStahn\JsonAssert\Tests\Extension;
 
 use EnricoStahn\JsonAssert\Extension\Symfony;
 use EnricoStahn\JsonAssert\Tests\Utils;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class SymfonyTest extends \PHPUnit_Framework_TestCase
+class SymfonyTest extends TestCase
 {
     public function testAssertJsonMatchesSchema()
     {


### PR DESCRIPTION
phpunit-json-assertions is currently not up to date with phpunit 6, which started using namespaces. 

It would be useful to bump phpunit-json-assertions' version with a support to phpunit 6. 

Also, I noticed that one of the unit tests (testAssertJsonMatchesSchemaWithRefsFails) is failing in both my changes and your master branch. I didn't dig around enough to try and fix it, but it's failing in your stable version, unless I did something wrong on my end.

