### PR TITLE
fix: assertInternalType invalid when $expected is NULL

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -85,7 +85,7 @@ trait Assert
         $result = \JmesPath\Env::search($expression, $json);
 
         \PHPUnit\Framework\Assert::assertEquals($expected, $result);
-        \PHPUnit\Framework\Assert::assertInternalType(gettype($expected), $result);
+        \PHPUnit\Framework\Assert::assertInternalType(strtolower(gettype($expected)), $result);
     }
 
     /**


### PR DESCRIPTION
gettype returns NULL and IsType accepts null string.