### PR TITLE
BREAKING CHANGE: Upgrade libraries, changing interfaces and introduci…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.0",
-        "justinrainbow/json-schema": "^2.0",
+        "justinrainbow/json-schema": "^5.0",
         "mtdowling/jmespath.php": "^2.3"
     },
     "require-dev": {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -11,10 +11,10 @@
 
 namespace EnricoStahn\JsonAssert;
 
-use JsonSchema\RefResolver;
-use JsonSchema\Uri\UriResolver;
-use JsonSchema\Uri\UriRetriever;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\SchemaStorage;
 use JsonSchema\Validator;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 /**
  * Asserts to validate JSON data.
@@ -26,24 +26,39 @@ use JsonSchema\Validator;
 trait Assert
 {
     /**
+     * @var SchemaStorage
+     */
+    private static $schemaStorage = null;
+
+    /**
      * Asserts that json content is valid according to the provided schema file.
      *
      * Example:
      *
-     *   static::assertJsonMatchesSchema('./schema.json', json_decode('{"foo":1}'))
+     *   static::assertJsonMatchesSchema(json_decode('{"foo":1}'), './schema.json')
      *
-     * @param string       $schema  Path to the schema file
+     * @param string|null  $schema  Path to the schema file
      * @param array|object $content JSON array or object
      */
-    public static function assertJsonMatchesSchema($schema, $content)
+    public static function assertJsonMatchesSchema($content, $schema = null)
     {
-        // Assume references are relative to the current file
-        // Create an issue or pull request if you need more complex use cases
-        $refResolver = new RefResolver(new UriRetriever(), new UriResolver());
-        $schemaObj = $refResolver->resolve('file://'.realpath($schema));
+        if (self::$schemaStorage === null) {
+            self::$schemaStorage = new SchemaStorage();
+        }
 
-        $validator = new Validator();
-        $validator->check($content, $schemaObj);
+        if ($schema !== null && !file_exists($schema)) {
+            throw new FileNotFoundException($schema);
+        }
+
+        $schemaObject = null;
+
+        if ($schema !== null) {
+            $schemaObject = json_decode(file_get_contents($schema));
+            self::$schemaStorage->addSchema( 'file://' . $schema, $schemaObject);
+        }
+
+        $validator = new Validator(new Factory(self::$schemaStorage));
+        $validator->validate($content, $schemaObject);
 
         $message = '- Property: %s, Contraint: %s, Message: %s';
         $messages = array_map(function ($exception) use ($message) {
@@ -52,6 +67,22 @@ trait Assert
         $messages[] = '- Response: '.json_encode($content);
 
         \PHPUnit\Framework\Assert::assertTrue($validator->isValid(), implode("\n", $messages));
+    }
+
+    /**
+     * Asserts that json content is valid according to the provided schema file.
+     *
+     * Example:
+     *
+     *   static::assertJsonMatchesSchema(json_decode('{"foo":1}'), './schema.json')
+     *
+     * @param string|null  $schema  Path to the schema file
+     * @param array|object $content JSON array or object
+     * @deprecated This will be removed in the next major version (4.x).
+     */
+    public static function assertJsonMatchesSchemaDepr($schema, $content)
+    {
+        self::assertJsonMatchesSchema($content, $schema);
     }
 
     /**
@@ -65,7 +96,7 @@ trait Assert
         $file = tempnam(sys_get_temp_dir(), 'json-schema-');
         file_put_contents($file, $schema);
 
-        self::assertJsonMatchesSchema($file, $content);
+        self::assertJsonMatchesSchema($content, $file);
     }
 
     /**

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -54,7 +54,7 @@ trait Assert
 
         if ($schema !== null) {
             $schemaObject = json_decode(file_get_contents($schema));
-            self::$schemaStorage->addSchema( 'file://' . $schema, $schemaObject);
+            self::$schemaStorage->addSchema('file://'.$schema, $schemaObject);
         }
 
         $validator = new Validator(new Factory(self::$schemaStorage));
@@ -78,6 +78,7 @@ trait Assert
      *
      * @param string|null  $schema  Path to the schema file
      * @param array|object $content JSON array or object
+     *
      * @deprecated This will be removed in the next major version (4.x).
      */
     public static function assertJsonMatchesSchemaDepr($schema, $content)

--- a/src/Extension/Symfony.php
+++ b/src/Extension/Symfony.php
@@ -28,7 +28,7 @@ trait Symfony
      */
     public static function assertJsonMatchesSchema($schema, Response $response)
     {
-        Assert::assertJsonMatchesSchema($schema, json_decode($response->getContent()));
+        Assert::assertJsonMatchesSchemaDepr($schema, json_decode($response->getContent()));
     }
 
     /**

--- a/tests/AssertTraitImpl.php
+++ b/tests/AssertTraitImpl.php
@@ -27,6 +27,7 @@ class AssertTraitImpl extends TestCase
     /**
      * @param string $id
      * @param string $schema
+     *
      * @return SchemaStorage
      */
     public function testWithSchemaStore($id, $schema)

--- a/tests/AssertTraitImpl.php
+++ b/tests/AssertTraitImpl.php
@@ -12,9 +12,27 @@
 namespace EnricoStahn\JsonAssert\Tests;
 
 use EnricoStahn\JsonAssert\Assert as JsonAssert;
+use JsonSchema\SchemaStorage;
 use PHPUnit\Framework\TestCase;
 
 class AssertTraitImpl extends TestCase
 {
     use JsonAssert;
+
+    public function setUp()
+    {
+        self::$schemaStorage = new SchemaStorage();
+    }
+
+    /**
+     * @param string $id
+     * @param string $schema
+     * @return SchemaStorage
+     */
+    public function testWithSchemaStore($id, $schema)
+    {
+        self::$schemaStorage->addSchema($id, $schema);
+
+        return self::$schemaStorage;
+    }
 }

--- a/tests/AssertTraitTest.php
+++ b/tests/AssertTraitTest.php
@@ -109,10 +109,10 @@ class AssertTraitTest extends TestCase
         $obj = new AssertTraitImpl();
         $obj->setUp();
 
-        $schemastore = $obj->testWithSchemaStore('foobar', (object)['type' => 'string']);
+        $schemastore = $obj->testWithSchemaStore('foobar', (object) ['type' => 'string']);
 
         self::assertInstanceOf('JsonSchema\SchemaStorage', $schemastore);
-        self::assertEquals($schemastore->getSchema('foobar'), (object)['type' => 'string']);
+        self::assertEquals($schemastore->getSchema('foobar'), (object) ['type' => 'string']);
     }
 
     public function assertJsonValueEqualsProvider()

--- a/tests/AssertTraitTest.php
+++ b/tests/AssertTraitTest.php
@@ -25,14 +25,14 @@ class AssertTraitTest extends TestCase
     {
         $content = json_decode(file_get_contents(Utils::getJsonPath('assertJsonMatchesSchema_simple.json')));
 
-        AssertTraitImpl::assertJsonMatchesSchema(Utils::getSchemaPath('assertJsonMatchesSchema_simple.schema.json'), $content);
+        AssertTraitImpl::assertJsonMatchesSchemaDepr(Utils::getSchemaPath('assertJsonMatchesSchema_simple.schema.json'), $content);
     }
 
     public function testAssertJsonMatchesSchema()
     {
         $content = json_decode('{"foo":123}');
 
-        AssertTraitImpl::assertJsonMatchesSchema(Utils::getSchemaPath('test.schema.json'), $content);
+        AssertTraitImpl::assertJsonMatchesSchemaDepr(Utils::getSchemaPath('test.schema.json'), $content);
     }
 
     /**
@@ -42,7 +42,7 @@ class AssertTraitTest extends TestCase
     {
         $content = json_decode('{"foo":"123"}');
 
-        AssertTraitImpl::assertJsonMatchesSchema(Utils::getSchemaPath('test.schema.json'), $content);
+        AssertTraitImpl::assertJsonMatchesSchemaDepr(Utils::getSchemaPath('test.schema.json'), $content);
     }
 
     public function testAssertJsonMatchesSchemaFailMessage()
@@ -52,7 +52,7 @@ class AssertTraitTest extends TestCase
         $exception = null;
 
         try {
-            AssertTraitImpl::assertJsonMatchesSchema(Utils::getSchemaPath('test.schema.json'), $content);
+            AssertTraitImpl::assertJsonMatchesSchemaDepr(Utils::getSchemaPath('test.schema.json'), $content);
         } catch (ExpectationFailedException $exception) {
             self::assertContains('- Property: foo, Contraint: type, Message: String value found, but an integer is required', $exception->getMessage());
             self::assertContains('- Response: {"foo":"123"}', $exception->getMessage());
@@ -68,7 +68,7 @@ class AssertTraitTest extends TestCase
     {
         $content = json_decode('{"code":123, "message":"Nothing works."}');
 
-        AssertTraitImpl::assertJsonMatchesSchema(Utils::getSchemaPath('error.schema.json'), $content);
+        AssertTraitImpl::assertJsonMatchesSchemaDepr(Utils::getSchemaPath('error.schema.json'), $content);
     }
 
     /**
@@ -78,7 +78,7 @@ class AssertTraitTest extends TestCase
     {
         $content = json_decode('{"code":"123", "message":"Nothing works."}');
 
-        AssertTraitImpl::assertJsonMatchesSchema(Utils::getSchemaPath('error.schema.json'), $content);
+        AssertTraitImpl::assertJsonMatchesSchemaDepr(Utils::getSchemaPath('error.schema.json'), $content);
     }
 
     public function testAssertJsonMatchesSchemaString()
@@ -102,6 +102,17 @@ class AssertTraitTest extends TestCase
         $content = json_decode(file_get_contents(Utils::getJsonPath('testAssertJsonValueEquals.json')));
 
         AssertTraitImpl::assertJsonValueEquals($value, $expression, $content);
+    }
+
+    public function testAssertWithSchemaStore()
+    {
+        $obj = new AssertTraitImpl();
+        $obj->setUp();
+
+        $schemastore = $obj->testWithSchemaStore('foobar', (object)['type' => 'string']);
+
+        self::assertInstanceOf('JsonSchema\SchemaStorage', $schemastore);
+        self::assertEquals($schemastore->getSchema('foobar'), (object)['type' => 'string']);
     }
 
     public function assertJsonValueEqualsProvider()


### PR DESCRIPTION
…ng schema storage

* `justinrainbow/json-schema` has been upgraded to the latest version (5.x)
* Interface for `assertJsonMatchesSchema` has changed from `assertJsonMatchesSchema($schema, $content)` to `assertJsonMatchesSchema($content, $schema = null)`
* Support for schema storage within traits (see README.md)